### PR TITLE
Add BFS scraper with React interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# scrape
+# Scrape
+
+This example provides a simple Python scraper and React front‑end. The scraper
+uses [ScraperAPI](https://www.scraperapi.com/) to fetch pages and traverses a
+domain in breadth‑first order. Pages are stored in MongoDB so already scraped
+URLs are skipped on subsequent runs.
+
+## Python usage
+
+```bash
+pip install -r requirements.txt
+python scraperapp/app.py
+```
+
+POST `/scrape` with JSON body containing `api_key` and `domain` or use the
+included React UI.
+
+## Frontend
+
+Open `http://localhost:5000` once the Flask app is running. Enter your
+ScraperAPI key and the domain to crawl, then press **Start Scraping**.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>Scraper</title>
+    <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body>
+<div id="root"></div>
+<script type="text/babel">
+function App() {
+    const [domain, setDomain] = React.useState("");
+    const [apiKey, setApiKey] = React.useState("");
+    const [message, setMessage] = React.useState("");
+
+    const startScrape = async () => {
+        const resp = await fetch('/scrape', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({domain, api_key: apiKey})
+        });
+        const data = await resp.json();
+        setMessage(data.message);
+    };
+
+    return (
+        <div>
+            <h1>Domain Scraper</h1>
+            <input placeholder="ScraperAPI key" value={apiKey} onChange={e => setApiKey(e.target.value)} />
+            <input placeholder="Domain" value={domain} onChange={e => setDomain(e.target.value)} />
+            <button onClick={startScrape}>Start Scraping</button>
+            <p>{message}</p>
+        </div>
+    );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));
+</script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+flask
+requests
+beautifulsoup4
+pymongo

--- a/scraperapp/app.py
+++ b/scraperapp/app.py
@@ -1,0 +1,28 @@
+from flask import Flask, request, jsonify, send_from_directory
+from scraper import BFSScraper
+import os
+
+app = Flask(__name__, static_folder="../frontend", static_url_path="")
+
+
+@app.route('/')
+def index():
+    return send_from_directory(app.static_folder, 'index.html')
+
+
+@app.route('/scrape', methods=['POST'])
+def scrape_route():
+    data = request.get_json() or {}
+    api_key = data.get('api_key')
+    domain = data.get('domain')
+    if not api_key or not domain:
+        return jsonify({'message': 'api_key and domain required'}), 400
+
+    scraper = BFSScraper(api_key, domain)
+    scraper.run()
+    return jsonify({'message': 'scraping finished'})
+
+
+if __name__ == '__main__':
+    port = int(os.environ.get('PORT', 5000))
+    app.run(host='0.0.0.0', port=port)

--- a/scraperapp/scraper.py
+++ b/scraperapp/scraper.py
@@ -1,0 +1,62 @@
+import requests
+from urllib.parse import urljoin, urlparse
+from bs4 import BeautifulSoup
+from collections import deque
+from pymongo import MongoClient
+
+
+class BFSScraper:
+    """Breadth-first scraper that stores results in MongoDB."""
+
+    def __init__(self, api_key, start_url, mongo_uri="mongodb://localhost:27017", db_name="scraper"):
+        self.api_key = api_key
+        self.start_url = start_url if start_url.startswith("http") else f"http://{start_url}"
+        parsed = urlparse(self.start_url)
+        self.base = f"{parsed.scheme}://{parsed.netloc}"
+        self.client = MongoClient(mongo_uri)
+        self.db = self.client[db_name]
+        self.pages = self.db.pages
+
+    def _already_scraped(self, url):
+        return self.pages.count_documents({"url": url}, limit=1) != 0
+
+    def fetch(self, url):
+        response = requests.get(
+            "http://api.scraperapi.com",
+            params={"api_key": self.api_key, "url": url},
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.text
+
+    def run(self):
+        queue = deque([self.start_url])
+        visited = set()
+        while queue:
+            url = queue.popleft()
+            if url in visited or self._already_scraped(url):
+                continue
+            try:
+                html = self.fetch(url)
+            except Exception:
+                continue
+            self.pages.insert_one({"url": url, "html": html})
+            visited.add(url)
+            soup = BeautifulSoup(html, "html.parser")
+            for tag in soup.find_all("a", href=True):
+                link = urljoin(url, tag["href"])
+                if link.startswith(self.base) and link not in visited:
+                    queue.append(link)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="BFS domain scraper")
+    parser.add_argument("api_key", help="ScraperAPI key")
+    parser.add_argument("domain", help="Domain to scrape")
+    parser.add_argument("--mongo", default="mongodb://localhost:27017", help="Mongo URI")
+    parser.add_argument("--db", default="scraper", help="MongoDB database")
+    args = parser.parse_args()
+
+    BFSScraper(args.api_key, args.domain, args.mongo, args.db).run()


### PR DESCRIPTION
## Summary
- implement BFS web crawler that avoids rescanning scraped URLs
- expose scraping via Flask API
- provide simple React interface for entering a ScraperAPI key and target domain
- document usage in README

## Testing
- `python -m py_compile scraperapp/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684749e761188325907ef7b6ae9cf6a8